### PR TITLE
moved search bar to nav bar in mobile

### DIFF
--- a/izu-beach-front/src/components/Navbar/Navbar.js
+++ b/izu-beach-front/src/components/Navbar/Navbar.js
@@ -32,29 +32,27 @@ export default function Navbar({setSearchResults}) {
     <Nav className="navbar">
       <a href="/"><ReactLogo /></a>
 
+      <Form className="d-flex" id="nav-search" onSubmit={handleSubmit} >
+        <Form.Control
+          icon="search"
+          type="search"
+          placeholder="Search a location!"
+          className="me-2"
+          aria-label="Search"
+          value={searchQuery}
+          onChange={handleSearchInputChange}
+        />
+      </Form>
+
       <div id="hamburger">
         <Hamburger rounded size={40} toggled={isOpen} toggle={() => setIsOpen(!isOpen)}/>
       </div>
 
       <div className={ isOpen ? "nav-menu expanded" : "nav-menu" }>
-
-        <Form className="d-flex mx-4" id="nav-search" onSubmit={handleSubmit} >
-          <Form.Control
-            icon="search"
-            type="search"
-            placeholder="Search a location!"
-            className="me-2"
-            aria-label="Search"
-            value={searchQuery}
-            onChange={handleSearchInputChange}
-          />
-        </Form>
-
         <Nav.Link as={Link} to="/beaches" onClick={() => setIsOpen(!isOpen)} >Beaches</Nav.Link>
         <Nav.Link as={Link} to="/about" onClick={() => setIsOpen(!isOpen)} >About</Nav.Link>
         <Nav.Link as={Link} to="/contribute" onClick={() => setIsOpen(!isOpen)} >Contribute</Nav.Link>
       </div>
-
     </Nav>
   )
 }

--- a/izu-beach-front/src/style/Navbar.scss
+++ b/izu-beach-front/src/style/Navbar.scss
@@ -1,5 +1,6 @@
 .navbar {
   background-color: $ocean-blue;
+  flex-wrap: nowrap;
 }
 
 .nav-menu {
@@ -14,19 +15,26 @@
   }
 }
 
+// .nav-menu-container {
+//   max-width: 100%;
+
+// }
+
 .nav-menu.expanded {
   display: block;
   position: absolute;
   top: 95px;
+  left: 0;
   width: 100%;
   flex-direction: column;
   width: 100%;
   background-color: $ocean-blue;
   padding-bottom: 0.5em;
+}
 
-  #nav-search {
-    margin: 15px 0;
-  }
+#nav-search {
+  width: 100%;
+  margin: 15px 0;
 }
 
 #hamburger {
@@ -53,6 +61,11 @@
 
     #hamburger {
       display: none;
+    }
+
+    #nav-search {
+      max-width: 20%;
+      margin-left: auto;
     }
   }
 }

--- a/izu-beach-front/src/style/Variables.scss
+++ b/izu-beach-front/src/style/Variables.scss
@@ -1,6 +1,7 @@
 // Our own declared variables will go here
 
 $mobile-breakpoint: 992px;
+// $tablet-breakpoint: ;
 
 $ocean-blue: #C9DDE9;
 $sunset-orange: #E9983E;


### PR DESCRIPTION
- not sure what to do about the size for tablet or font size for mobile s
- how big should the search bar be in tablet view? full width like it is for mobile? Or smaller and positioned to the left like desktop?
<img width="1272" alt="tablet" src="https://user-images.githubusercontent.com/97200803/219017016-6622a368-f6c7-4ac3-800e-5b364ab99874.png">

- And in mobile s, the placeholder text doesn't fit all the way.
- Should we reduce the font size?  
<img width="1251" alt="mobile s" src="https://user-images.githubusercontent.com/97200803/219017257-427b35f4-982c-4dde-8bdb-444963069eb5.png">
